### PR TITLE
Offerel Dev Changes

### DIFF
--- a/calendar/calendar.php
+++ b/calendar/calendar.php
@@ -92,6 +92,10 @@ class calendar extends rcube_plugin
     }
 
     $this->add_hook('user_delete', array($this, 'user_delete'));
+
+    if ($this->rc->task == 'calendar') {
+      $this->rc->output->set_env('refresh_interval', 0);
+    }
   }
 
   /**

--- a/calendar/drivers/caldav/SQL/mysql.initial.sql
+++ b/calendar/drivers/caldav/SQL/mysql.initial.sql
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS `caldav_calendars` (
   `color` varchar(8) NOT NULL,
   `showalarms` tinyint(1) NOT NULL DEFAULT '1',
 
-  `caldav_url` varchar(255) NOT NULL,
+  `caldav_url` varchar(1000) NOT NULL,
   `caldav_tag` varchar(255) DEFAULT NULL,
   `caldav_user` varchar(255) DEFAULT NULL,
   `caldav_pass` varchar(1024) DEFAULT NULL,
@@ -53,7 +53,7 @@ CREATE TABLE IF NOT EXISTS `caldav_events` (
   `sequence` int(1) UNSIGNED NOT NULL DEFAULT '0',
   `start` datetime NOT NULL DEFAULT '1000-01-01 00:00:00',
   `end` datetime NOT NULL DEFAULT '1000-01-01 00:00:00',
-  `recurrence` varchar(255) DEFAULT NULL,
+  `recurrence` varchar(1000) DEFAULT NULL,
   `title` varchar(255) NOT NULL,
   `description` text NOT NULL,
   `location` varchar(255) NOT NULL DEFAULT '',
@@ -68,7 +68,7 @@ CREATE TABLE IF NOT EXISTS `caldav_events` (
   `attendees` text DEFAULT NULL,
   `notifyat` datetime DEFAULT NULL,
 
-  `caldav_url` varchar(255) NOT NULL,
+  `caldav_url` varchar(1000) NOT NULL,
   `caldav_tag` varchar(255) DEFAULT NULL,
   `caldav_last_change` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 

--- a/calendar/drivers/caldav/caldav_driver.php
+++ b/calendar/drivers/caldav/caldav_driver.php
@@ -48,7 +48,7 @@ class caldav_driver extends calendar_driver
     // Holds CalDAV sync clients
     private $sync_clients = array();
     // Min. time period to wait until CalDAV sync check.
-    private $sync_period = 10; // seconds
+    private $sync_period = 600; // value in seconds, 600sec=10minutes, original was 10
     // Indicates debug mode for CalDAV
     static private $debug = null;
     /**


### PR DESCRIPTION
I have made 3 changes so far:

* Suppress Refreshing: disables the refresh function to minimize http requests. Runs only when calendar plugin is active and resets to original value, when its not active. Maybe its better to make this optional, but for now it's hard coded.
* Change minimal sync interval from 60 seconds (original value) to 600 seconds (10 Minutes), to prevents spamming the DAV server. Should we make this as an option in settings?
* Fixed a bug (or at least weak setting) in MySQL initial SQL file which otherwise leads to a 'data too long for column...' error